### PR TITLE
Remove unstable feature: never_type

### DIFF
--- a/append_db/src/backend/memory.rs
+++ b/append_db/src/backend/memory.rs
@@ -1,6 +1,6 @@
 pub use crate::backend::class::{SnapshotedUpdate, State, StateBackend};
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{sync::Arc, convert::Infallible};
 use tokio::sync::Mutex;
 
 #[derive(Clone)]
@@ -25,7 +25,7 @@ impl<St: State> Default for InMemory<St> {
 #[async_trait]
 impl<St: Clone + State + 'static + Send> StateBackend for InMemory<St> {
     type State = St;
-    type Err = !;
+    type Err = Infallible;
 
     async fn write(&mut self, upd: SnapshotedUpdate<Self::State>) -> Result<(), Self::Err> {
         self.updates.lock().await.push(upd);

--- a/append_db/src/lib.rs
+++ b/append_db/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 pub mod backend;
 pub mod db;
 
@@ -9,6 +8,7 @@ mod tests {
     use super::backend::class::{SnapshotedUpdate, State, StateBackend};
     use super::backend::memory::InMemory;
     use super::db::AppendDb;
+    use std::convert::Infallible;
     use std::ops::Deref;
 
     #[derive(Clone, Debug, PartialEq)]
@@ -24,7 +24,7 @@ mod tests {
 
     impl State for State0 {
         type Update = Update0;
-        type Err = !;
+        type Err = Infallible;
 
         fn update(&mut self, upd: Update0) -> Result<(), Self::Err> {
             match upd {

--- a/append_db_postgres/src/lib.rs
+++ b/append_db_postgres/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 pub mod backend;
 pub mod update;
 
@@ -16,6 +15,7 @@ mod tests {
     use append_db::db::AppendDb;
     use append_db_postgres_derive::*;
     use serde::{Deserialize, Serialize};
+    use std::convert::Infallible;
     use std::ops::Deref;
     use crate as append_db_postgres;
 
@@ -32,7 +32,7 @@ mod tests {
 
     impl State for State0 {
         type Update = Update0;
-        type Err = !;
+        type Err = Infallible;
 
         fn update(&mut self, upd: Update0) -> Result<(), Self::Err> {
             match upd {


### PR DESCRIPTION
The crate uses unstable feature: `never_type` for no apparent reason, since it can use `std::convert::Infallible` which is stable, performs the same function and once `never_type` is stabilized would be turned into a type alias for `!`